### PR TITLE
Throw an exception instead of exit when Secp256k1::getByte() is not a hex

### DIFF
--- a/bsgsd.cpp
+++ b/bsgsd.cpp
@@ -2385,8 +2385,8 @@ void* client_handler(void* arg) {
 			close(client_fd);
 			pthread_exit(NULL);
 		}
-	} catch (const std::invalid_argument &e) {
-          printf("%s\n", e.what());
+	} catch (const std::invalid_argument *e) {
+          printf("%s\n", e->what());
           freetokenizer(&t);
           sendstr(client_fd,"400 Bad Request");
           close(client_fd);

--- a/bsgsd.cpp
+++ b/bsgsd.cpp
@@ -11,6 +11,7 @@ email: albertobsd@gmail.com
 #include <time.h>
 #include <vector>
 #include <inttypes.h>
+#include <stdexcept>
 #include "base58/libbase58.h"
 #include "rmd160/rmd160.h"
 #include "oldbloom/oldbloom.h"
@@ -2376,13 +2377,22 @@ void* client_handler(void* arg) {
 		pthread_exit(NULL);
 	}
 
-	if(!secp->ParsePublicKeyHex(t.tokens[0],OriginalPointsBSGS,OriginalPointsBSGScompressed))	{
-		printf("Invalid publickey format from client %s\n",t.tokens[0]);
-		freetokenizer(&t);
-		sendstr(client_fd,"400 Bad Request");
-		close(client_fd);
-		pthread_exit(NULL);		
-	}
+	try {
+		if(!secp->ParsePublicKeyHex(t.tokens[0],OriginalPointsBSGS,OriginalPointsBSGScompressed))	{
+			printf("Invalid publickey format from client %s\n",t.tokens[0]);
+			freetokenizer(&t);
+			sendstr(client_fd,"400 Bad Request");
+			close(client_fd);
+			pthread_exit(NULL);
+		}
+	} catch (const std::invalid_argument &e) {
+          printf("%s\n", e.what());
+          freetokenizer(&t);
+          sendstr(client_fd,"400 Bad Request");
+          close(client_fd);
+          pthread_exit(NULL);
+    }
+
 	if(!(isValidHex(t.tokens[1]) && isValidHex(t.tokens[1])))	{
 		printf("Invalid hexadecimal format from client %s:%s\n",t.tokens[1],t.tokens[2]);
 		freetokenizer(&t);

--- a/secp256k1/SECP256K1.cpp
+++ b/secp256k1/SECP256K1.cpp
@@ -17,6 +17,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <stdexcept>
 #include "SECP256k1.h"
 #include "Point.h"
 #include "../util.h"
@@ -94,8 +95,7 @@ uint8_t Secp256K1::GetByte(char *str, int idx) {
   tmp[1] = str[2 * idx + 1];
   tmp[2] = 0;
   if (sscanf(tmp, "%X", &val) != 1) {
-    printf("ParsePublicKeyHex: Error invalid public key specified (unexpected hexadecimal digit)\n");
-    exit(-1);
+    throw new std::invalid_argument("ParsePublicKeyHex: Error invalid public key specified (unexpected hexadecimal digit)");
   }
   return (uint8_t)val;
 }


### PR DESCRIPTION
This PR fix the #256 
In bsgsd daemon terminates when getByte calls exit(-1).
it replaced by throw an invalid_argument exception and then try ... catch in client_handler. 