### PR TITLE
:building_construction: Refactor Windows compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+.specstory/

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,10 @@ endif
 # MinGW-specific flags (used by target `mingw`)
 CFLAGS_MINGW := -m64 -march=x86-64 -mssse3 -Wall -Wextra -Wno-unused-parameter -Ofast -ftree-vectorize
 CXXFLAGS_MINGW := -m64 -march=x86-64 -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize
-LDFLAGS_MINGW := -lm -lws2_32 -lbcrypt
-THREAD_FLAGS_MINGW := -pthread
+# Link libgcc and libstdc++ statically so exe doesn't require libgcc_s_seh-1.dll or libstdc++-6.dll
+LDFLAGS_MINGW := -static-libgcc -static-libstdc++ -lm -lws2_32 -lbcrypt
+# Do not request pthread linkage for MinGW build (avoid libwinpthread dependency)
+THREAD_FLAGS_MINGW :=
 
 default:
 	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c oldbloom/bloom.cpp -o oldbloom.o

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ default:
 	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/keccak.c -o keccak.o
 	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c xxhash/xxhash.c -o xxhash.o
 	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c util.c -o util.o
+	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c os_random.c -o os_random.o
+	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c win_compat.c -o win_compat.o
+	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c win_thread_compat.c -o win_thread_compat.o
 	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Int.cpp -o Int.o
 	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Point.cpp -o Point.o
 	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/SECP256K1.cpp -o SECP256K1.o
@@ -36,9 +39,32 @@ legacy:
 	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -c gmp256k1/IntMod.cpp -o IntMod.o
 	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -flto -c gmp256k1/Random.cpp -o Random.o
 	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -flto -c gmp256k1/IntGroup.cpp -o IntGroup.o
-	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -o keyhunt keyhunt_legacy.cpp base58.o bloom.o oldbloom.o xxhash.o util.o Int.o  Point.o GMP256K1.o  IntMod.o  IntGroup.o Random.o hashing.o sha3.o keccak.o -lm -lpthread -lcrypto -lgmp	
+	gcc -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -c os_random.c -o os_random.o
+	gcc -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -c win_compat.c -o win_compat.o
+	gcc -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -c win_thread_compat.c -o win_thread_compat.o
+	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -o keyhunt keyhunt_legacy.cpp base58.o bloom.o oldbloom.o xxhash.o util.o os_random.o win_compat.o win_thread_compat.o Int.o  Point.o GMP256K1.o  IntMod.o  IntGroup.o Random.o hashing.o sha3.o keccak.o -lm -lpthread -lcrypto -lgmp	
 	rm -r *.o
-bsgsd:
+
+CC ?= gcc
+CXX ?= g++
+AR ?= ar
+CFLAGS ?= -Wall -Wextra
+CXXFLAGS ?= -Wall -Wextra -Wno-deprecated-copy
+LDFLAGS ?= -lm
+
+# MinGW detection
+MACHINE := $(shell $(CXX) -dumpmachine 2>/dev/null)
+ifneq (,$(findstring mingw,$(MACHINE)))
+    IS_MINGW := 1
+endif
+
+# MinGW-specific flags (used by target `mingw`)
+CFLAGS_MINGW := -m64 -march=x86-64 -mssse3 -Wall -Wextra -Wno-unused-parameter -Ofast -ftree-vectorize
+CXXFLAGS_MINGW := -m64 -march=x86-64 -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize
+LDFLAGS_MINGW := -lm -lws2_32 -lbcrypt
+THREAD_FLAGS_MINGW := -pthread
+
+default:
 	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c oldbloom/bloom.cpp -o oldbloom.o
 	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c bloom/bloom.cpp -o bloom.o
 	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-unused-parameter -Ofast -ftree-vectorize -c base58/base58.c -o base58.o
@@ -57,5 +83,31 @@ bsgsd:
 	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256.o -ftree-vectorize -flto -c hash/sha256.cpp
 	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160_sse.o -ftree-vectorize -flto -c hash/ripemd160_sse.cpp
 	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256_sse.o -ftree-vectorize -flto -c hash/sha256_sse.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -o bsgsd bsgsd.cpp base58.o rmd160.o hash/ripemd160.o hash/ripemd160_sse.o hash/sha256.o hash/sha256_sse.o bloom.o oldbloom.o xxhash.o util.o Int.o  Point.o SECP256K1.o  IntMod.o  Random.o IntGroup.o sha3.o keccak.o  -lm -lpthread
+	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o keyhunt keyhunt.cpp base58.o rmd160.o hash/ripemd160.o hash/ripemd160_sse.o hash/sha256.o hash/sha256_sse.o bloom.o oldbloom.o xxhash.o util.o os_random.o win_compat.o win_thread_compat.o Int.o  Point.o SECP256K1.o  IntMod.o  Random.o IntGroup.o sha3.o keccak.o  -lm -lpthread
+	rm -r *.o
+
+# Target for building with MinGW (MSYS2 mingw64)
+.PHONY: mingw
+mingw:
+	$(CXX) $(CXXFLAGS_MINGW) -c oldbloom/bloom.cpp -o oldbloom.o
+	$(CXX) $(CXXFLAGS_MINGW) -c bloom/bloom.cpp -o bloom.o
+	$(CC) $(CFLAGS_MINGW) -c base58/base58.c -o base58.o
+	$(CC) $(CFLAGS_MINGW) -c rmd160/rmd160.c -o rmd160.o
+	$(CXX) $(CXXFLAGS_MINGW) -c sha3/sha3.c -o sha3.o
+	$(CXX) $(CXXFLAGS_MINGW) -c sha3/keccak.c -o keccak.o
+	$(CC) $(CFLAGS_MINGW) -c xxhash/xxhash.c -o xxhash.o
+	$(CXX) $(CXXFLAGS_MINGW) -c util.c -o util.o
+	$(CC) $(CFLAGS_MINGW) -c os_random.c -o os_random.o
+	$(CC) $(CFLAGS_MINGW) -c win_compat.c -o win_compat.o
+	$(CXX) $(CXXFLAGS_MINGW) -c secp256k1/Int.cpp -o Int.o
+	$(CXX) $(CXXFLAGS_MINGW) -c secp256k1/Point.cpp -o Point.o
+	$(CXX) $(CXXFLAGS_MINGW) -c secp256k1/SECP256K1.cpp -o SECP256K1.o
+	$(CXX) $(CXXFLAGS_MINGW) -c secp256k1/IntMod.cpp -o IntMod.o
+	$(CXX) $(CXXFLAGS_MINGW) -c secp256k1/Random.cpp -o Random.o
+	$(CXX) $(CXXFLAGS_MINGW) -c secp256k1/IntGroup.cpp -o IntGroup.o
+	$(CXX) $(CXXFLAGS_MINGW) -o hash/ripemd160.o -c hash/ripemd160.cpp
+	$(CXX) $(CXXFLAGS_MINGW) -o hash/sha256.o -c hash/sha256.cpp
+	$(CXX) $(CXXFLAGS_MINGW) -o hash/ripemd160_sse.o -c hash/ripemd160_sse.cpp
+	$(CXX) $(CXXFLAGS_MINGW) -o hash/sha256_sse.o -c hash/sha256_sse.cpp
+	$(CXX) $(CXXFLAGS_MINGW) -o keyhunt keyhunt.cpp base58.o rmd160.o hash/ripemd160.o hash/ripemd160_sse.o hash/sha256.o hash/sha256_sse.o bloom.o oldbloom.o xxhash.o util.o os_random.o win_compat.o Int.o Point.o SECP256K1.o IntMod.o Random.o IntGroup.o sha3.o keccak.o $(LDFLAGS_MINGW) $(THREAD_FLAGS_MINGW)
 	rm -r *.o

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,9 @@ endif
 CFLAGS_MINGW := -m64 -march=x86-64 -mssse3 -Wall -Wextra -Wno-unused-parameter -Ofast -ftree-vectorize
 CXXFLAGS_MINGW := -m64 -march=x86-64 -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize
 # Link libgcc and libstdc++ statically so exe doesn't require libgcc_s_seh-1.dll or libstdc++-6.dll
-LDFLAGS_MINGW := -static-libgcc -static-libstdc++ -lm -lws2_32 -lbcrypt
+# Link libgcc and libstdc++ statically and link winpthread statically to avoid libwinpthread-1.dll
+# Use -Wl,-Bstatic/-Bdynamic around -lwinpthread so other system libs remain dynamic
+LDFLAGS_MINGW := -static-libgcc -static-libstdc++ -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic -lm -lws2_32 -lbcrypt
 # Do not request pthread linkage for MinGW build (avoid libwinpthread dependency)
 THREAD_FLAGS_MINGW :=
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,46 @@ and then execute with `-h` to see the help
 ./keyhunt -h
 ```
 
+## Windows build (MinGW)
+
+If you want to build natively on Windows, the recommended approach is to use MSYS2 / MinGW-w64 (use the `MINGW64` shell). Below are the minimal tested steps to produce the `keyhunt.exe` binary.
+
+- Prerequisites (MSYS2 MINGW64):
+
+  - Install MSYS2: https://www.msys2.org/
+  - Open the `MSYS2 MinGW 64-bit` shell (MINGW64).
+
+- Update the system and install required packages:
+
+```bash
+pacman -Syu            # may ask to close/reopen the shell per instructions
+pacman -S --needed base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-pkg-config \
+    mingw-w64-x86_64-gmp mingw-w64-x86_64-openssl mingw-w64-x86_64-make
+```
+
+- Clone and build (from the MINGW64 shell):
+
+```bash
+git clone https://github.com/albertobsd/keyhunt.git
+cd keyhunt
+make mingw
+```
+
+The `make mingw` target uses a MinGW-specific `Makefile` and links the necessary Windows libraries (`-lws2_32 -lbcrypt`) while compiling the objects required for Windows.
+
+- Run the test binary (e.g. `test.bat`):
+
+In Explorer double-click `test.bat` or run from the shell:
+
+```bash
+./keyhunt.exe -d -m address -f tests/66.txt -b 66 -l compress -R -s 10
+```
+
+Notes and troubleshooting:
+
+- If the linker complains about missing `-lbcrypt`, ensure you are using the `MINGW64` shell (the MinGW toolchain provides the proper import libraries). If needed, you can try linking `-ladvapi32` and adjust `os_random.c` to use `CryptGenRandom` as a fallback.
+- If the program starts and then immediately exits, run it with `-d` (debug) and without `-q` (quiet), capture output to a log (the provided `test.bat` already does this) and check `run.log` for messages such as `"[E] Error os_getrandom() ?"` which indicate RNG API issues on Windows.
+
 ## ¡Beta!
 
 This version is still a **beta** version, there are a lot of things that can be fail or improve.

--- a/base58/base58.c
+++ b/base58/base58.c
@@ -5,10 +5,11 @@
  * under the terms of the standard MIT license.  See COPYING for more details.
  */
 
-#ifndef _WIN64
-#include <arpa/inet.h>
-#else
+/* Use Winsock on Windows (including MinGW); otherwise use POSIX arpa/inet.h */
+#if defined(_WIN32)
 #include <winsock2.h>
+#else
+#include <arpa/inet.h>
 #endif
 
 #include <stdbool.h>

--- a/bloom/bloom.h
+++ b/bloom/bloom.h
@@ -8,7 +8,7 @@
 #ifndef _BLOOM_H
 #define _BLOOM_H
 
-#ifdef _WIN64
+#if defined(_WIN64) && !defined(__MINGW32__) && !defined(__MINGW64__)
 #include <windows.h>
 #endif
 

--- a/bsgsd.cpp
+++ b/bsgsd.cpp
@@ -29,12 +29,18 @@ email: albertobsd@gmail.com
 
 #include <unistd.h>
 #include <pthread.h>
+#if !defined(__MINGW32__) && !defined(__MINGW64__)
 #include <sys/random.h>
 #include <linux/random.h>
-
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h> // for inet_addr()
+#else
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#endif
+#include "win_compat.h"
+#include "os_random.h"
 #include <pthread.h>   // for pthread functions
 
 #define PORT 8080
@@ -66,7 +72,7 @@ struct tothread {
 struct bPload	{
 	uint32_t threadid;
 	uint64_t from;
-	uint64_t to;
+	int osr = os_getrandom(&rseedvalue, sizeof(unsigned long));
 	uint64_t counter;
 	uint64_t workload;
 	uint32_t aux;
@@ -315,7 +321,8 @@ int main(int argc, char **argv)	{
 	pthread_mutex_init(&write_random,NULL);
 	pthread_mutex_init(&mutex_bsgs_thread,NULL);
 
-	srand(time(NULL));
+	// Initialize sockets for Windows compatibility (no-op on POSIX)
+	socket_init();
 
 	secp = new Secp256K1();
 	secp->Init();
@@ -324,9 +331,9 @@ int main(int argc, char **argv)	{
 	BSGS_GROUP_SIZE.SetInt32(CPU_GRP_SIZE);
 	
 	unsigned long rseedvalue;
-	int bytes_read = getrandom(&rseedvalue, sizeof(unsigned long), GRND_NONBLOCK);
-	if(bytes_read > 0)	{
-		rseed(rseedvalue);
+	int osr = os_getrandom(&rseedvalue, sizeof(unsigned long));
+	    if(osr == 0)	{
+		    rseed(rseedvalue);
 		/*
 		In any case that seed is for a failsafe RNG, the default source on linux is getrandom function
 		See https://www.2uo.de/myths-about-urandom/
@@ -337,9 +344,9 @@ int main(int argc, char **argv)	{
 			what year is??
 			WTF linux without RNG ? 
 		*/
-		fprintf(stderr,"[E] Error getrandom() ?\n");
+		fprintf(stderr,"[E] Error os_getrandom() ?\n");
 		exit(0);
-		rseed(clock() + time(NULL) + rand()*rand());
+		rseed(clock() + time(NULL));
 	}
 	
 	port = PORT;
@@ -1361,7 +1368,7 @@ int main(int argc, char **argv)	{
 		fflush(stdout);
 	}
 	
-	close(server_fd);
+	socket_close(server_fd);
 }
 
 void pubkeytopubaddress_dst(char *pkey,int length,char *dst)	{
@@ -1944,9 +1951,9 @@ void calcualteindex(int i,Int *key)	{
 }
 
 
-void sleep_ms(int milliseconds)	{ // cross-platform sleep function
-#if defined(_WIN64) && !defined(__CYGWIN__)
-    Sleep(milliseconds);
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+void sleep_ms(int milliseconds) 	{ // cross-platform sleep function
+	Sleep(milliseconds);
 #elif _POSIX_C_SOURCE >= 199309L
     struct timespec ts;
     ts.tv_sec = milliseconds / 1000;
@@ -2352,7 +2359,7 @@ void* client_handler(void* arg) {
 	// Peek at the incoming data to determine its length
 	bytes_received = recv(client_fd, buffer, sizeof(buffer) - 1, MSG_PEEK);
 	if (bytes_received <= 0) {
-		close(client_fd);
+		socket_close(client_fd);
 		pthread_exit(NULL);
 	}
 	
@@ -2361,7 +2368,7 @@ void* client_handler(void* arg) {
 	size_t line_length = newline ? (newline - buffer) + 1 : bytes_received;
 	bytes_received = recv(client_fd, buffer, line_length, 0);
 	if (bytes_received <= 0)	{
-		close(client_fd);
+		socket_close(client_fd);
 		pthread_exit(NULL);
 	}
 
@@ -2372,7 +2379,7 @@ void* client_handler(void* arg) {
 		printf("Invalid input format from client, tokens %i : %s\n",t.n, buffer);
 		freetokenizer(&t);
 		sendstr(client_fd,"400 Bad Request");
-		close(client_fd);
+		socket_close(client_fd);
 		pthread_exit(NULL);
 	}
 
@@ -2380,7 +2387,7 @@ void* client_handler(void* arg) {
 		printf("Invalid publickey format from client %s\n",t.tokens[0]);
 		freetokenizer(&t);
 		sendstr(client_fd,"400 Bad Request");
-		close(client_fd);
+		socket_close(client_fd);
 		pthread_exit(NULL);		
 	}
 	if(!(isValidHex(t.tokens[1]) && isValidHex(t.tokens[2])))	{
@@ -2454,7 +2461,7 @@ void* client_handler(void* arg) {
 	}
 
 	
-    close(client_fd);
+	socket_close(client_fd);
     pthread_exit(NULL);
 }
 

--- a/gmp256k1/Random.cpp
+++ b/gmp256k1/Random.cpp
@@ -4,19 +4,7 @@
 #include <gmp.h>
 
 
-#if  defined(_WIN32) || defined(_WIN64)
-    #include <Windows.h>
-    #include <bcrypt.h>
-    #pragma comment(lib, "bcrypt.lib")
-#elif __unix__ || __unix || __APPLE__ || __MACH__ || __CYGWIN__
-    #include <unistd.h>
-    #include <fcntl.h>
-    #include <sys/syscall.h>
-    #include <linux/random.h>
-    #if defined(GRND_NONBLOCK)
-        #define USE_GETRANDOM
-    #endif
-#endif
+#include "../os_random.h"
 
 #include "Int.h"
 
@@ -67,28 +55,7 @@ void Int::Rand(Int *min,Int *max)	{
 	this->Add(min);
 }
 
-int random_bytes(unsigned char *buffer,int bytes)	{
-    #if defined(_WIN32) || defined(_WIN64)
-        if (!BCryptGenRandom(NULL, buffer, length, BCRYPT_USE_SYSTEM_PREFERRED_RNG)) {
-            fprintf(stderr,"Not BCryptGenRandom available\n");
-			exit(EXIT_FAILURE);
-        }
-		else
-			return bytes;
-	#elif __unix__ || __unix || __APPLE__ || __MACH__ || __CYGWIN__
-		#ifdef USE_GETRANDOM
-			return syscall(SYS_getrandom, buffer, bytes, GRND_NONBLOCK);
-		#else
-            int fd = open("/dev/urandom", O_RDONLY);
-            if (fd == -1) {
-				fprintf(stderr,"Not /dev/urandom available\n");
-				exit(EXIT_FAILURE);
-            }
-            ssize_t result = read(fd, buffer, bytes);
-            close(fd);
-			return result;
-        #endif
-    #else
-        #error "Unsupported platform"
-    #endif
+int random_bytes(unsigned char *buffer,int bytes) {
+	if (os_getrandom(buffer, bytes) == 0) return bytes;
+	return -1;
 }

--- a/hash/ripemd160_sse.cpp
+++ b/hash/ripemd160_sse.cpp
@@ -22,7 +22,7 @@
 // Internal SSE RIPEMD-160 implementation.
 namespace ripemd160sse {
 
-#ifdef WIN64
+#if defined(_WIN64) && !defined(__MINGW32__) && !defined(__MINGW64__)
   static const __declspec(align(16)) uint32_t _init[] = {
 #else
   static const uint32_t _init[] __attribute__ ((aligned (16))) = {
@@ -42,7 +42,7 @@ namespace ripemd160sse {
 
 #define ROL(x,n) _mm_or_si128( _mm_slli_epi32(x, n) , _mm_srli_epi32(x, 32 - n) )
 
-#ifdef WIN64
+#if defined(_WIN64) && !defined(__MINGW32__) && !defined(__MINGW64__)
 
 #define not(x) _mm_andnot_si128(x, _mm_cmpeq_epi32(_mm_setzero_si128(), _mm_setzero_si128()))
 #define f1(x,y,z) _mm_xor_si128(x, _mm_xor_si128(y, z))
@@ -297,7 +297,8 @@ namespace ripemd160sse {
 
 } // namespace ripemd160sse
 
-#ifdef WIN64
+
+#if defined(_WIN64) && !defined(__MINGW32__) && !defined(__MINGW64__)
 
 #define DEPACK(d,i) \
 ((uint32_t *)d)[0] = s[0].m128i_u32[i]; \
@@ -345,7 +346,8 @@ void ripemd160sse_32(
 
   ripemd160sse::Transform(s, bs);
 
-#ifndef WIN64
+/* Declare pointer accessors for GCC/MinGW path (non-MSVC) */
+#if !defined(_WIN64) || defined(__MINGW32__) || defined(__MINGW64__)
   uint32_t *s0 = (uint32_t *)&s[0];
   uint32_t *s1 = (uint32_t *)&s[1];
   uint32_t *s2 = (uint32_t *)&s[2];

--- a/hash/sha256_sse.cpp
+++ b/hash/sha256_sse.cpp
@@ -24,7 +24,7 @@ namespace _sha256sse
 {
 
 
-#ifdef WIN64
+#if defined(WIN64) && !defined(__MINGW32__) && !defined(__MINGW64__)
   static const __declspec(align(16)) uint32_t _init[] = {
 #else
   static const uint32_t _init[] __attribute__ ((aligned (16))) = {
@@ -561,17 +561,21 @@ void sha256sse_checksum(uint32_t *i0, uint32_t *i1, uint32_t *i2, uint32_t *i3,
   _sha256sse::Initialize(s);
   _sha256sse::Transform2(s, i0, i1, i2, i3);
 
-#ifndef WIN64
+// Use MSVC-specific layout member access on native Windows builds
+// but ensure MinGW (which defines __MINGW32__/__MINGW64__) uses the
+// GCC-compatible path. This avoids referencing .m128i_u32 on __m128i
+// which is not a class type under GCC.
+#if defined(WIN64) && !defined(__MINGW32__) && !defined(__MINGW64__)
+  *((uint32_t *)d0) = _byteswap_ulong(s[0].m128i_u32[3]);
+  *((uint32_t *)d1) = _byteswap_ulong(s[0].m128i_u32[2]);
+  *((uint32_t *)d2) = _byteswap_ulong(s[0].m128i_u32[1]);
+  *((uint32_t *)d3) = _byteswap_ulong(s[0].m128i_u32[0]);
+#else
   uint32_t *s32 = (uint32_t *)(&s[0]);
   *((uint32_t *)d0) = __builtin_bswap32(s32[3]);
   *((uint32_t *)d1) = __builtin_bswap32(s32[2]);
   *((uint32_t *)d2) = __builtin_bswap32(s32[1]);
   *((uint32_t *)d3) = __builtin_bswap32(s32[0]);
-#else
-  *((uint32_t *)d0) = _byteswap_ulong(s[0].m128i_u32[3]);
-  *((uint32_t *)d1) = _byteswap_ulong(s[0].m128i_u32[2]);
-  *((uint32_t *)d2) = _byteswap_ulong(s[0].m128i_u32[1]);
-  *((uint32_t *)d3) = _byteswap_ulong(s[0].m128i_u32[0]);
 #endif
 
 }

--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -27,13 +27,15 @@ email: albertobsd@gmail.com
 #include "hash/sha256.h"
 #include "hash/ripemd160.h"
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#include "win_compat.h"
+
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 #include "getopt.h"
 #include <windows.h>
 #else
 #include <unistd.h>
 #include <pthread.h>
-#include <sys/random.h>
+#include "os_random.h"
 #endif
 
 #ifdef __unix__
@@ -92,7 +94,7 @@ struct bPload	{
 	uint32_t finished;
 };
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 #define PACK( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop))
 PACK(struct publickey
 {
@@ -186,7 +188,7 @@ bool initBloomFilter(struct bloom *bloom_arg,uint64_t items_bloom);
 void writeFileIfNeeded(const char *fileName);
 
 void calcualteindex(int i,Int *key);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 DWORD WINAPI thread_process_vanity(LPVOID vargp);
 DWORD WINAPI thread_process_minikeys(LPVOID vargp);
 DWORD WINAPI thread_process(LPVOID vargp);
@@ -230,7 +232,7 @@ const char *cryptos[3] = {"btc","eth","all"};
 const char *publicsearch[3] = {"uncompress","compress","both"};
 const char *default_fileName = "addresses.txt";
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 HANDLE* tid = NULL;
 HANDLE write_keys;
 HANDLE write_random;
@@ -342,7 +344,7 @@ struct checksumsha256 *bloom_bP_checksums;
 struct checksumsha256 *bloom_bPx2nd_checksums;
 struct checksumsha256 *bloom_bPx3rd_checksums;
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 std::vector<HANDLE> bloom_bP_mutex;
 std::vector<HANDLE> bloom_bPx2nd_mutex;
 std::vector<HANDLE> bloom_bPx3rd_mutex;
@@ -437,7 +439,7 @@ int main(int argc, char **argv)	{
 	struct bPload *bPload_temp_ptr;
 	size_t rsize;
 	
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 	DWORD s;
 	write_keys = CreateMutex(NULL, FALSE, NULL);
 	write_random = CreateMutex(NULL, FALSE, NULL);
@@ -458,29 +460,15 @@ int main(int argc, char **argv)	{
 	ONE.SetInt32(1);
 	BSGS_GROUP_SIZE.SetInt32(CPU_GRP_SIZE);
 	
-#if defined(_WIN64) && !defined(__CYGWIN__)
-	//Any windows secure random source goes here
-	rseed(clock() + time(NULL) + rand());
-#else
 	unsigned long rseedvalue;
-	int bytes_read = getrandom(&rseedvalue, sizeof(unsigned long), GRND_NONBLOCK);
-	if(bytes_read > 0)	{
+	int bytes_read = os_getrandom(&rseedvalue, sizeof(rseedvalue));
+	if (bytes_read == 0) {
 		rseed(rseedvalue);
-		/*
-		In any case that seed is for a failsafe RNG, the default source on linux is getrandom function
-		See https://www.2uo.de/myths-about-urandom/
-		*/
-	}
-	else	{
-		/*
-			what year is??
-			WTF linux without RNG ? 
-		*/
-		fprintf(stderr,"[E] Error getrandom() ?\n");
+	} else {
+		fprintf(stderr,"[E] Error os_getrandom() ?\n");
 		exit(EXIT_FAILURE);
-		rseed(clock() + time(NULL) + rand()*rand());
+		rseed(clock() + time(NULL));
 	}
-#endif
 	
 	
 	
@@ -567,7 +555,7 @@ int main(int argc, char **argv)	{
 					}
 				}
 				else	{
-					fprintf(stderr,"[E] Invalid Minikey length %li : %s\n",strlen(optarg),optarg);
+					fprintf(stderr,"[E] Invalid Minikey length %zu : %s\n",strlen(optarg),optarg);
 					exit(EXIT_FAILURE);
 				}
 				
@@ -1218,7 +1206,7 @@ int main(int argc, char **argv)	{
 		bloom_bP_checksums = (struct checksumsha256*)calloc(256,sizeof(struct checksumsha256));
 		checkpointer((void *)bloom_bP_checksums,__FILE__,"calloc","bloom_bP_checksums" ,__LINE__ -1 );
 		
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 		bloom_bP_mutex = (HANDLE*) calloc(256,sizeof(HANDLE));
 		
 #else
@@ -1230,7 +1218,7 @@ int main(int argc, char **argv)	{
 		fflush(stdout);
 		bloom_bP_totalbytes = 0;
 		for(i=0; i< 256; i++)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 			bloom_bP_mutex[i] = CreateMutex(NULL, FALSE, NULL);
 #else
 			pthread_mutex_init(&bloom_bP_mutex[i],NULL);
@@ -1247,10 +1235,10 @@ int main(int argc, char **argv)	{
 
 		printf("[+] Bloom filter for %" PRIu64 " elements ",bsgs_m2);
 		
-#if defined(_WIN64) && !defined(__CYGWIN__)
-		bloom_bPx2nd_mutex = (HANDLE*) calloc(256,sizeof(HANDLE));
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+	bloom_bPx2nd_mutex = (HANDLE*) calloc(256,sizeof(HANDLE));
 #else
-		bloom_bPx2nd_mutex = (pthread_mutex_t*) calloc(256,sizeof(pthread_mutex_t));
+	bloom_bPx2nd_mutex = (pthread_mutex_t*) calloc(256,sizeof(pthread_mutex_t));
 #endif
 		checkpointer((void *)bloom_bPx2nd_mutex,__FILE__,"calloc","bloom_bPx2nd_mutex" ,__LINE__ -1 );
 		bloom_bPx2nd = (struct bloom*)calloc(256,sizeof(struct bloom));
@@ -1258,12 +1246,12 @@ int main(int argc, char **argv)	{
 		bloom_bPx2nd_checksums = (struct checksumsha256*) calloc(256,sizeof(struct checksumsha256));
 		checkpointer((void *)bloom_bPx2nd_checksums,__FILE__,"calloc","bloom_bPx2nd_checksums" ,__LINE__ -1 );
 		bloom_bP2_totalbytes = 0;
-		for(i=0; i< 256; i++)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
-			bloom_bPx2nd_mutex[i] = CreateMutex(NULL, FALSE, NULL);
-#else
-			pthread_mutex_init(&bloom_bPx2nd_mutex[i],NULL);
-#endif
+		for(i=0; i< 256; i++) {
+	#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+		    bloom_bPx2nd_mutex[i] = CreateMutex(NULL, FALSE, NULL);
+	#else
+		    pthread_mutex_init(&bloom_bPx2nd_mutex[i],NULL);
+	#endif
 			if(bloom_init2(&bloom_bPx2nd[i],itemsbloom2,0.000001)	== 1){
 				fprintf(stderr,"[E] error bloom_init _ [%" PRIu64 "]\n",i);
 				exit(EXIT_FAILURE);
@@ -1274,10 +1262,10 @@ int main(int argc, char **argv)	{
 		printf(": %.2f MB\n",(float)((float)(uint64_t)bloom_bP2_totalbytes/(float)(uint64_t)1048576));
 		
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
-		bloom_bPx3rd_mutex = (HANDLE*) calloc(256,sizeof(HANDLE));
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+	bloom_bPx3rd_mutex = (HANDLE*) calloc(256,sizeof(HANDLE));
 #else
-		bloom_bPx3rd_mutex = (pthread_mutex_t*) calloc(256,sizeof(pthread_mutex_t));
+	bloom_bPx3rd_mutex = (pthread_mutex_t*) calloc(256,sizeof(pthread_mutex_t));
 #endif
 		checkpointer((void *)bloom_bPx3rd_mutex,__FILE__,"calloc","bloom_bPx3rd_mutex" ,__LINE__ -1 );
 		bloom_bPx3rd = (struct bloom*)calloc(256,sizeof(struct bloom));
@@ -1287,12 +1275,12 @@ int main(int argc, char **argv)	{
 		
 		printf("[+] Bloom filter for %" PRIu64 " elements ",bsgs_m3);
 		bloom_bP3_totalbytes = 0;
-		for(i=0; i< 256; i++)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
-			bloom_bPx3rd_mutex[i] = CreateMutex(NULL, FALSE, NULL);
-#else
-			pthread_mutex_init(&bloom_bPx3rd_mutex[i],NULL);
-#endif
+		for(i=0; i< 256; i++) {
+	#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+		    bloom_bPx3rd_mutex[i] = CreateMutex(NULL, FALSE, NULL);
+	#else
+		    pthread_mutex_init(&bloom_bPx3rd_mutex[i],NULL);
+	#endif
 			if(bloom_init2(&bloom_bPx3rd[i],itemsbloom3,0.000001)	== 1){
 				fprintf(stderr,"[E] error bloom_init [%" PRIu64 "]\n",i);
 				exit(EXIT_FAILURE);
@@ -1639,7 +1627,7 @@ int main(int argc, char **argv)	{
 				printf("\r[+] processing %lu/%lu bP points : %i%%\r",FINISHED_ITEMS,bsgs_m,(int) (((double)FINISHED_ITEMS/(double)bsgs_m)*100));
 				fflush(stdout);
 				
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				tid = (HANDLE*)calloc(NTHREADS, sizeof(HANDLE));
 				checkpointer((void *)tid,__FILE__,"calloc","tid" ,__LINE__ -1 );
 				bPload_mutex = (HANDLE*) calloc(NTHREADS,sizeof(HANDLE));
@@ -1656,7 +1644,7 @@ int main(int argc, char **argv)	{
 				memset(bPload_threads_available,1,NTHREADS);
 				
 				for(j = 0; j < NTHREADS; j++)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 					bPload_mutex[j] = CreateMutex(NULL, FALSE, NULL);
 #else
 					pthread_mutex_init(&bPload_mutex[j],NULL);
@@ -1680,7 +1668,7 @@ int main(int argc, char **argv)	{
 								bPload_temp_ptr[j].workload = THREADBPWORKLOAD + PERTHREAD_R;
 								salir = 1;
 							}
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 							tid[j] = CreateThread(NULL, 0, thread_bPload_2blooms, (void*) &bPload_temp_ptr[j], 0, &s);
 #else
 							s = pthread_create(&tid[j],NULL,thread_bPload_2blooms,(void*) &bPload_temp_ptr[j]);
@@ -1699,7 +1687,7 @@ int main(int argc, char **argv)	{
 					
 					for(j = 0 ; j < NTHREADS ; j++)	{
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 						WaitForSingleObject(bPload_mutex[j], INFINITE);
 						finished = bPload_temp_ptr[j].finished;
 						ReleaseMutex(bPload_mutex[j]);
@@ -1750,10 +1738,10 @@ int main(int argc, char **argv)	{
 				printf("\r[+] processing %lu/%lu bP points : %i%%\r",FINISHED_ITEMS,bsgs_m,(int) (((double)FINISHED_ITEMS/(double)bsgs_m)*100));
 				fflush(stdout);
 				
-#if defined(_WIN64) && !defined(__CYGWIN__)
-				tid = (HANDLE*)calloc(NTHREADS, sizeof(HANDLE));
-				bPload_mutex = (HANDLE*) calloc(NTHREADS,sizeof(HANDLE));
-#else
+		#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+			tid = (HANDLE*)calloc(NTHREADS, sizeof(HANDLE));
+			bPload_mutex = (HANDLE*) calloc(NTHREADS,sizeof(HANDLE));
+		#else
 				tid = (pthread_t *) calloc(NTHREADS,sizeof(pthread_t));
 				bPload_mutex = (pthread_mutex_t*) calloc(NTHREADS,sizeof(pthread_mutex_t));
 #endif
@@ -1768,12 +1756,12 @@ int main(int argc, char **argv)	{
 
 				memset(bPload_threads_available,1,NTHREADS);
 				
-				for(j = 0; j < NTHREADS; j++)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+				for(j = 0; j < NTHREADS; j++) {
+			#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 					bPload_mutex = CreateMutex(NULL, FALSE, NULL);
-#else
+			#else
 					pthread_mutex_init(&bPload_mutex[j],NULL);
-#endif
+			#endif
 				}
 				
 				do	{
@@ -1795,9 +1783,9 @@ int main(int argc, char **argv)	{
 								//if(FLAGDEBUG) printf("[D] Salir OK\n");
 							}
 							//if(FLAGDEBUG) printf("[I] %lu to %lu\n",bPload_temp_ptr[i].from,bPload_temp_ptr[i].to);
-#if defined(_WIN64) && !defined(__CYGWIN__)
-							tid[j] = CreateThread(NULL, 0, thread_bPload, (void*) &bPload_temp_ptr[j], 0, &s);
-#else
+				#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+					tid[j] = CreateThread(NULL, 0, thread_bPload, (void*) &bPload_temp_ptr[j], 0, &s);
+				#else
 							s = pthread_create(&tid[j],NULL,thread_bPload,(void*) &bPload_temp_ptr[j]);
 							pthread_detach(tid[j]);
 #endif
@@ -1813,7 +1801,7 @@ int main(int argc, char **argv)	{
 					
 					for(j = 0 ; j < NTHREADS ; j++)	{
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 						WaitForSingleObject(bPload_mutex[j], INFINITE);
 						finished = bPload_temp_ptr[j].finished;
 						ReleaseMutex(bPload_mutex[j]);
@@ -2031,7 +2019,7 @@ int main(int argc, char **argv)	{
 		checkpointer((void *)steps,__FILE__,"calloc","steps" ,__LINE__ -1 );
 		ends = (unsigned int *) calloc(NTHREADS,sizeof(int));
 		checkpointer((void *)ends,__FILE__,"calloc","ends" ,__LINE__ -1 );
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 		tid = (HANDLE*)calloc(NTHREADS, sizeof(HANDLE));
 #else
 		tid = (pthread_t *) calloc(NTHREADS,sizeof(pthread_t));
@@ -2044,8 +2032,8 @@ int main(int argc, char **argv)	{
 			tt->nt = j;
 			steps[j] = 0;
 			s = 0;
-			switch(FLAGBSGSMODE)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+			switch(FLAGBSGSMODE)    {
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				case 0:
 					tid[j] = CreateThread(NULL, 0, thread_process_bsgs, (void*)tt, 0, &s);
 					break;
@@ -2061,7 +2049,6 @@ int main(int argc, char **argv)	{
 				case 4:
 					tid[j] = CreateThread(NULL, 0, thread_process_bsgs_dance, (void*)tt, 0, &s);
 					break;
-				}
 #else
 				case 0:
 					s = pthread_create(&tid[j],NULL,thread_process_bsgs,(void *)tt);
@@ -2080,7 +2067,7 @@ int main(int argc, char **argv)	{
 				break;
 #endif
 			}
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 			if (tid[j] == NULL) {
 #else
 			if(s != 0)	{
@@ -2096,7 +2083,7 @@ int main(int argc, char **argv)	{
 		checkpointer((void *)steps,__FILE__,"calloc","steps" ,__LINE__ -1 );
 		ends = (unsigned int *) calloc(NTHREADS,sizeof(int));
 		checkpointer((void *)ends,__FILE__,"calloc","ends" ,__LINE__ -1 );
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 		tid = (HANDLE*)calloc(NTHREADS, sizeof(HANDLE));
 #else
 		tid = (pthread_t *) calloc(NTHREADS,sizeof(pthread_t));
@@ -2108,19 +2095,19 @@ int main(int argc, char **argv)	{
 			tt->nt = j;
 			steps[j] = 0;
 			s = 0;
-			switch(FLAGMODE)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+			switch(FLAGMODE)    {
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				case MODE_ADDRESS:
 				case MODE_XPOINT:
 				case MODE_RMD160:
 					tid[j] = CreateThread(NULL, 0, thread_process, (void*)tt, 0, &s);
-				break;
+					break;
 				case MODE_MINIKEYS:
 					tid[j] = CreateThread(NULL, 0, thread_process_minikeys, (void*)tt, 0, &s);
-				break;
+					break;
 				case MODE_VANITY:
 					tid[j] = CreateThread(NULL, 0, thread_process_vanity, (void*)tt, 0, &s);
-				break;
+					break;
 #else
 				case MODE_ADDRESS:
 				case MODE_XPOINT:
@@ -2186,7 +2173,7 @@ int main(int argc, char **argv)	{
 					}
 				}
 				
-#ifdef _WIN64
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				WaitForSingleObject(bsgs_thread, INFINITE);
 #else
 				pthread_mutex_lock(&bsgs_thread);
@@ -2238,7 +2225,7 @@ int main(int argc, char **argv)	{
 				printf("%s",buffer);
 				fflush(stdout);
 				THREADOUTPUT = 0;			
-#ifdef _WIN64
+#if defined(_WIN64) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				ReleaseMutex(bsgs_thread);
 #else
 				pthread_mutex_unlock(&bsgs_thread);
@@ -2251,7 +2238,7 @@ int main(int argc, char **argv)	{
 		}
 	}while(continue_flag);
 	printf("\nEnd\n");
-#ifdef _WIN64
+#if defined(_WIN64) && !defined(__MINGW32__) && !defined(__MINGW64__)
 	CloseHandle(write_keys);
 	CloseHandle(write_random);
 	CloseHandle(bsgs_thread);
@@ -2334,7 +2321,7 @@ int searchbinary(struct address_value *buffer,char *data,int64_t array_length) {
 	return r;
 }
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 DWORD WINAPI thread_process_minikeys(LPVOID vargp) {
 #else
 void *thread_process_minikeys(void *vargp)	{
@@ -2373,7 +2360,7 @@ void *thread_process_minikeys(void *vargp)	{
 		}
 		else	{
 			if(FLAGBASEMINIKEY)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				WaitForSingleObject(write_random, INFINITE);
 				memcpy(buffer_b58,raw_baseminikey,21);
 				increment_minikey_N(raw_baseminikey);
@@ -2386,7 +2373,7 @@ void *thread_process_minikeys(void *vargp)	{
 #endif
 			}
 			else	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				WaitForSingleObject(write_random, INFINITE);
 #else
 				pthread_mutex_lock(&write_random);
@@ -2406,7 +2393,7 @@ void *thread_process_minikeys(void *vargp)	{
 					memcpy(buffer_b58,raw_baseminikey,21);
 					increment_minikey_N(raw_baseminikey);
 				}
-#if defined(_WIN64) && !defined(__CYGWIN__)				
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				ReleaseMutex(write_random);
 #else
 				pthread_mutex_unlock(&write_random);
@@ -2471,7 +2458,7 @@ void *thread_process_minikeys(void *vargp)	{
 								/* hit */
 								hextemp = key_mpz[k].GetBase16();
 								secp->GetPublicKeyHex(false,publickey[k],public_key_uncompressed_hex);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 								WaitForSingleObject(write_keys, INFINITE);
 #else
 								pthread_mutex_lock(&write_keys);
@@ -2485,7 +2472,7 @@ void *thread_process_minikeys(void *vargp)	{
 									fclose(keys);
 								}
 								printf("\nHIT!! Private Key: %s\npubkey: %s\nminikey: %s\naddress: %s\n",hextemp,public_key_uncompressed_hex,minikeys[k],address[k]);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 								ReleaseMutex(write_keys);
 #else
 								pthread_mutex_unlock(&write_keys);
@@ -2505,7 +2492,7 @@ void *thread_process_minikeys(void *vargp)	{
 }
 
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 DWORD WINAPI thread_process(LPVOID vargp) {
 #else
 void *thread_process(void *vargp)	{
@@ -2550,7 +2537,7 @@ void *thread_process(void *vargp)	{
 		}
 		else	{
 			if(n_range_start.IsLower(&n_range_end))	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				WaitForSingleObject(write_random, INFINITE);
 				key_mpz.Set(&n_range_start);
 				n_range_start.Add(N_SEQUENTIAL_MAX);
@@ -3099,7 +3086,7 @@ void *thread_process(void *vargp)	{
 }
 
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 DWORD WINAPI thread_process_vanity(LPVOID vargp) {
 #else
 void *thread_process_vanity(void *vargp)	{
@@ -3146,7 +3133,7 @@ void *thread_process_vanity(void *vargp)	{
 		printf("[D] vanity_rmd_targets = %i          fillllll\n",vanity_rmd_targets);
 		printf("[D] vanity_rmd_total = %i\n",vanity_rmd_total);
 		for(i =0; i < vanity_rmd_targets;i++)	{
-			printf("[D] vanity_rmd_limits[%li] = %i\n",i,vanity_rmd_limits[i]);
+			printf("[D] vanity_rmd_limits[%d] = %i\n",i,vanity_rmd_limits[i]);
 			
 		}
 		printf("[D] vanity_rmd_minimun_bytes_check_length = %i\n",vanity_rmd_minimun_bytes_check_length);
@@ -3160,7 +3147,7 @@ void *thread_process_vanity(void *vargp)	{
 		}
 		else	{
 			if(n_range_start.IsLower(&n_range_end))	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				WaitForSingleObject(write_random, INFINITE);
 				key_mpz.Set(&n_range_start);
 				n_range_start.Add(N_SEQUENTIAL_MAX);
@@ -3772,7 +3759,7 @@ int bsgs_searchbinary(struct bsgs_xvalue *buffer,char *data,int64_t array_length
 	return r;
 }
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 DWORD WINAPI thread_process_bsgs(LPVOID vargp) {
 #else
 void *thread_process_bsgs(void *vargp)	{
@@ -3821,7 +3808,7 @@ void *thread_process_bsgs(void *vargp)	{
 		We do this in an atomic pthread_mutex operation to not affect others threads
 		so BSGS_CURRENT is never the same between threads
 	*/
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 		WaitForSingleObject(bsgs_thread, INFINITE);
 #else
 		pthread_mutex_lock(&bsgs_thread);
@@ -3834,7 +3821,7 @@ void *thread_process_bsgs(void *vargp)	{
 		BSGS_CURRENT.Add(&BSGS_N);		//Then add BSGS_N to BSGS_CURRENT
 		*/
 		
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 		ReleaseMutex(bsgs_thread);
 #else
 		pthread_mutex_unlock(&bsgs_thread);
@@ -3952,7 +3939,7 @@ pn.y.ModAdd(&GSn[i].y);
 								point_found = secp->ComputePublicKey(&keyfound);
 								aux_c = secp->GetPublicKeyHex(OriginalPointsBSGScompressed[k],point_found);
 								printf("[+] Publickey %s\n",aux_c);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 								WaitForSingleObject(write_keys, INFINITE);
 #else
 								pthread_mutex_lock(&write_keys);
@@ -3965,7 +3952,7 @@ pn.y.ModAdd(&GSn[i].y);
 								}
 								free(hextemp);
 								free(aux_c);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				ReleaseMutex(write_keys);
 #else
 				pthread_mutex_unlock(&write_keys);
@@ -4008,7 +3995,7 @@ pn.y.ModAdd(&GSn[i].y);
 	return NULL;
 }
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 DWORD WINAPI thread_process_bsgs_random(LPVOID vargp) {
 #else
 void *thread_process_bsgs_random(void *vargp)	{
@@ -4060,14 +4047,14 @@ void *thread_process_bsgs_random(void *vargp)	{
 		-b	bit | Min bit value | Max bit value |
 		-r	A:B | A             | B             |
 	*/
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 		WaitForSingleObject(bsgs_thread, INFINITE);
 #else
 		pthread_mutex_lock(&bsgs_thread);
 #endif
 
 		base_key.Rand(&n_range_start,&n_range_end);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 		ReleaseMutex(bsgs_thread);
 #else
 		pthread_mutex_unlock(&bsgs_thread);
@@ -4201,7 +4188,7 @@ pn.y.ModAdd(&GSn[i].y);
 								point_found = secp->ComputePublicKey(&keyfound);
 								aux_c = secp->GetPublicKeyHex(OriginalPointsBSGScompressed[k],point_found);
 								printf("[+] Publickey %s\n",aux_c);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 								WaitForSingleObject(write_keys, INFINITE);
 #else
 								pthread_mutex_lock(&write_keys);
@@ -4214,7 +4201,7 @@ pn.y.ModAdd(&GSn[i].y);
 								}
 								free(hextemp);
 								free(aux_c);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 								ReleaseMutex(write_keys);
 #else
 								pthread_mutex_unlock(&write_keys);
@@ -4368,7 +4355,7 @@ int bsgs_thirdcheck(Int *start_range,uint32_t a,uint32_t k_index,Int *privatekey
 }
 
 void sleep_ms(int milliseconds)	{ // cross-platform sleep function
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
     Sleep(milliseconds);
 #elif _POSIX_C_SOURCE >= 199309L
     struct timespec ts;
@@ -4398,7 +4385,7 @@ void init_generator()	{
 	_2Gn = secp->DoubleDirect(Gn[CPU_GRP_SIZE / 2 - 1]);
 }
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 DWORD WINAPI thread_bPload(LPVOID vargp) {
 #else
 void *thread_bPload(void *vargp)	{
@@ -4526,7 +4513,7 @@ void *thread_bPload(void *vargp)	{
 					bPtable[i_counter].index = i_counter;
 				}
 				if(!FLAGREADEDFILE4)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 					WaitForSingleObject(bloom_bPx3rd_mutex[bloom_bP_index], INFINITE);
 					bloom_add(&bloom_bPx3rd[bloom_bP_index], rawvalue, BSGS_BUFFERXPOINTLENGTH);
 					ReleaseMutex(bloom_bPx3rd_mutex[bloom_bP_index]);
@@ -4538,7 +4525,7 @@ void *thread_bPload(void *vargp)	{
 				}
 			}
 			if(i_counter < bsgs_m2 && !FLAGREADEDFILE2)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				WaitForSingleObject(bloom_bPx2nd_mutex[bloom_bP_index], INFINITE);
 				bloom_add(&bloom_bPx2nd[bloom_bP_index], rawvalue, BSGS_BUFFERXPOINTLENGTH);
 				ReleaseMutex(bloom_bPx2nd_mutex[bloom_bP_index]);
@@ -4549,10 +4536,10 @@ void *thread_bPload(void *vargp)	{
 #endif	
 			}
 			if(i_counter < to && !FLAGREADEDFILE1 )	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				WaitForSingleObject(bloom_bP_mutex[bloom_bP_index], INFINITE);
 				bloom_add(&bloom_bP[bloom_bP_index], rawvalue ,BSGS_BUFFERXPOINTLENGTH);
-				ReleaseMutex(bloom_bP_mutex[bloom_bP_index);
+				ReleaseMutex(bloom_bP_mutex[bloom_bP_index]);
 #else
 				pthread_mutex_lock(&bloom_bP_mutex[bloom_bP_index]);
 				bloom_add(&bloom_bP[bloom_bP_index], rawvalue ,BSGS_BUFFERXPOINTLENGTH);
@@ -4578,7 +4565,7 @@ void *thread_bPload(void *vargp)	{
 		startP = pp;
 	}
 	delete grp;
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 	WaitForSingleObject(bPload_mutex[threadid], INFINITE);
 	tt->finished = 1;
 	ReleaseMutex(bPload_mutex[threadid]);
@@ -4591,7 +4578,7 @@ void *thread_bPload(void *vargp)	{
 	return NULL;
 }
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 DWORD WINAPI thread_bPload_2blooms(LPVOID vargp) {
 #else
 void *thread_bPload_2blooms(void *vargp)	{
@@ -4709,7 +4696,7 @@ void *thread_bPload_2blooms(void *vargp)	{
 					bPtable[i_counter].index = i_counter;
 				}
 				if(!FLAGREADEDFILE4)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 					WaitForSingleObject(bloom_bPx3rd_mutex[bloom_bP_index], INFINITE);
 					bloom_add(&bloom_bPx3rd[bloom_bP_index], rawvalue, BSGS_BUFFERXPOINTLENGTH);
 					ReleaseMutex(bloom_bPx3rd_mutex[bloom_bP_index]);
@@ -4721,7 +4708,7 @@ void *thread_bPload_2blooms(void *vargp)	{
 				}
 			}
 			if(i_counter < bsgs_m2 && !FLAGREADEDFILE2)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 					WaitForSingleObject(bloom_bPx2nd_mutex[bloom_bP_index], INFINITE);
 					bloom_add(&bloom_bPx2nd[bloom_bP_index], rawvalue, BSGS_BUFFERXPOINTLENGTH);
 					ReleaseMutex(bloom_bPx2nd_mutex[bloom_bP_index]);
@@ -4750,7 +4737,7 @@ void *thread_bPload_2blooms(void *vargp)	{
 		startP = pp;
 	}
 	delete grp;
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 	WaitForSingleObject(bPload_mutex[threadid], INFINITE);
 	tt->finished = 1;
 	ReleaseMutex(bPload_mutex[threadid]);
@@ -4788,7 +4775,7 @@ void generate_binaddress_eth(Point &publickey,unsigned char *dst_address)	{
 	memcpy(dst_address,bin_publickey+12,20);
 }
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 DWORD WINAPI thread_process_bsgs_dance(LPVOID vargp) {
 #else
 void *thread_process_bsgs_dance(void *vargp)	{
@@ -4828,7 +4815,7 @@ void *thread_process_bsgs_dance(void *vargp)	{
 	*/
 	do	{
 		r = rand() % 3;
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 	WaitForSingleObject(bsgs_thread, INFINITE);
 #else
 	pthread_mutex_lock(&bsgs_thread);
@@ -4870,7 +4857,7 @@ void *thread_process_bsgs_dance(void *vargp)	{
 			base_key.Rand(&BSGS_CURRENT,&n_range_end);
 		break;
 	}
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 	ReleaseMutex(bsgs_thread);
 #else
 	pthread_mutex_unlock(&bsgs_thread);
@@ -5006,7 +4993,7 @@ pn.y.ModAdd(&GSn[i].y);
 								point_found = secp->ComputePublicKey(&keyfound);
 								aux_c = secp->GetPublicKeyHex(OriginalPointsBSGScompressed[k],point_found);
 								printf("[+] Publickey %s\n",aux_c);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 								WaitForSingleObject(write_keys, INFINITE);
 #else
 								pthread_mutex_lock(&write_keys);
@@ -5019,7 +5006,7 @@ pn.y.ModAdd(&GSn[i].y);
 								}
 								free(hextemp);
 								free(aux_c);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 								ReleaseMutex(write_keys);
 #else
 								pthread_mutex_unlock(&write_keys);
@@ -5066,7 +5053,7 @@ pn.y.ModAdd(&GSn[i].y);
 	return NULL;
 }
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 DWORD WINAPI thread_process_bsgs_backward(LPVOID vargp) {
 #else
 void *thread_process_bsgs_backward(void *vargp)	{
@@ -5114,7 +5101,7 @@ void *thread_process_bsgs_backward(void *vargp)	{
 	*/
 	do	{
 		
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 		WaitForSingleObject(bsgs_thread, INFINITE);
 #else
 		pthread_mutex_lock(&bsgs_thread);
@@ -5131,7 +5118,7 @@ void *thread_process_bsgs_backward(void *vargp)	{
 		else	{
 			entrar = 0;
 		}
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 		ReleaseMutex(bsgs_thread);
 #else
 		pthread_mutex_unlock(&bsgs_thread);
@@ -5264,7 +5251,7 @@ pn.y.ModAdd(&GSn[i].y);
 								point_found = secp->ComputePublicKey(&keyfound);
 								aux_c = secp->GetPublicKeyHex(OriginalPointsBSGScompressed[k],point_found);
 								printf("[+] Publickey %s\n",aux_c);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 								WaitForSingleObject(write_keys, INFINITE);
 #else
 								pthread_mutex_lock(&write_keys);
@@ -5277,7 +5264,7 @@ pn.y.ModAdd(&GSn[i].y);
 								}
 								free(hextemp);
 								free(aux_c);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 								ReleaseMutex(write_keys);
 #else
 								pthread_mutex_unlock(&write_keys);
@@ -5323,7 +5310,7 @@ pn.y.ModAdd(&GSn[i].y);
 	return NULL;
 }
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 DWORD WINAPI thread_process_bsgs_both(LPVOID vargp) {
 #else
 void *thread_process_bsgs_both(void *vargp)	{
@@ -5374,7 +5361,7 @@ void *thread_process_bsgs_both(void *vargp)	{
 	do	{
 
 		r = rand() % 2;
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 		WaitForSingleObject(bsgs_thread, INFINITE);
 #else
 		pthread_mutex_lock(&bsgs_thread);
@@ -5413,7 +5400,7 @@ void *thread_process_bsgs_both(void *vargp)	{
 				}
 			break;
 		}
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 		ReleaseMutex(bsgs_thread);
 #else
 		pthread_mutex_unlock(&bsgs_thread);
@@ -5548,7 +5535,7 @@ void *thread_process_bsgs_both(void *vargp)	{
 									point_found = secp->ComputePublicKey(&keyfound);
 									aux_c = secp->GetPublicKeyHex(OriginalPointsBSGScompressed[k],point_found);
 									printf("[+] Publickey %s\n",aux_c);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 									WaitForSingleObject(write_keys, INFINITE);
 #else
 									pthread_mutex_lock(&write_keys);
@@ -5561,7 +5548,7 @@ void *thread_process_bsgs_both(void *vargp)	{
 									}
 									free(hextemp);
 									free(aux_c);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 									ReleaseMutex(write_keys);
 #else
 									pthread_mutex_unlock(&write_keys);
@@ -5812,7 +5799,7 @@ void writevanitykey(bool compressed,Int *key)	{
 	hexrmd = tohex(rmdhash,20);
 	rmd160toaddress_dst(rmdhash,address);
 	
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 	WaitForSingleObject(write_keys, INFINITE);
 #else
 	pthread_mutex_lock(&write_keys);
@@ -5824,7 +5811,7 @@ void writevanitykey(bool compressed,Int *key)	{
 	}
 	printf("\nVanity Private Key: %s\npubkey: %s\nAddress %s\nrmd160 %s\n",hextemp,public_key_hex,address,hexrmd);
 	
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 	ReleaseMutex(write_keys);
 #else
 	pthread_mutex_unlock(&write_keys);
@@ -5999,7 +5986,7 @@ void writekey(bool compressed,Int *key)	{
 	hexrmd = tohex(rmdhash,20);
 	rmd160toaddress_dst(rmdhash,address);
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 	WaitForSingleObject(write_keys, INFINITE);
 #else
 	pthread_mutex_lock(&write_keys);
@@ -6011,7 +5998,7 @@ void writekey(bool compressed,Int *key)	{
 	}
 	printf("\nHit! Private Key: %s\npubkey: %s\nAddress %s\nrmd160 %s\n",hextemp,public_key_hex,address,hexrmd);
 	
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 	ReleaseMutex(write_keys);
 #else
 	pthread_mutex_unlock(&write_keys);
@@ -6031,7 +6018,7 @@ void writekeyeth(Int *key)	{
 	address[1] = 'x';
 	tohex_dst(hash,20,address+2);
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 	WaitForSingleObject(write_keys, INFINITE);
 #else
 	pthread_mutex_lock(&write_keys);
@@ -6042,7 +6029,7 @@ void writekeyeth(Int *key)	{
 		fclose(keys);
 	}
 	printf("\n Hit!!!! Private Key: %s\naddress: %s\n",hextemp,address);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 	ReleaseMutex(write_keys);
 #else
 	pthread_mutex_unlock(&write_keys);
@@ -6532,7 +6519,7 @@ bool forceReadFileXPoint(char *fileName)	{
 						}
 					break;
 					default:
-						fprintf(stderr,"[E] Omiting line unknow length size %li: %s\n",lenaux,aux);
+						fprintf(stderr,"[E] Omiting line unknow length size %zu: %s\n",lenaux,aux);
 					break;
 				}
 			}
@@ -6592,7 +6579,7 @@ void writeFileIfNeeded(const char *fileName)	{
 		snprintf(fileBloomName,30,"data_%s.dat",hexPrefix);
 		fileDescriptor = fopen(fileBloomName,"wb");
 		dataSize = N * (sizeof(struct address_value));
-		printf("[D] size data %li\n",dataSize);
+				printf("[D] size data %" PRIu64 "\n",dataSize);
 		if(fileDescriptor != NULL)	{
 			printf("[+] Writing file %s ",fileBloomName);
 			

--- a/keyhunt_legacy.cpp
+++ b/keyhunt_legacy.cpp
@@ -22,21 +22,26 @@ email: albertobsd@gmail.com
 #include "gmp256k1/Int.h"
 #include "gmp256k1/IntGroup.h"
 #include "gmp256k1/Random.h"
+#include "win_compat.h"
 
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 #include "getopt.h"
 #include <windows.h>
 #else
 #include <unistd.h>
 #include <pthread.h>
+#if !defined(__MINGW32__) && !defined(__MINGW64__)
 #include <sys/random.h>
+#endif
 #endif
 
 #ifdef __unix__
 #ifdef __CYGWIN__
 #else
+#if !defined(__MINGW32__) && !defined(__MINGW64__)
 #include <linux/random.h>
+#endif
 #endif
 #endif
 
@@ -89,7 +94,7 @@ struct bPload	{
 	uint32_t finished;
 };
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 #define PACK( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop))
 PACK(struct publickey
 {
@@ -184,7 +189,7 @@ void writeFileIfNeeded(const char *fileName);
 
 void calcualteindex(int i,Int *key);
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 DWORD WINAPI thread_process_vanity(LPVOID vargp);
 DWORD WINAPI thread_process_minikeys(LPVOID vargp);
 DWORD WINAPI thread_process(LPVOID vargp);
@@ -230,7 +235,7 @@ const char *cryptos[3] = {"btc","eth","all"};
 const char *publicsearch[3] = {"uncompress","compress","both"};
 const char *default_fileName = "addresses.txt";
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 HANDLE* tid = NULL;
 HANDLE write_keys;
 HANDLE write_random;
@@ -342,7 +347,7 @@ struct checksumsha256 *bloom_bP_checksums;
 struct checksumsha256 *bloom_bPx2nd_checksums;
 struct checksumsha256 *bloom_bPx3rd_checksums;
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 std::vector<HANDLE> bloom_bP_mutex;
 std::vector<HANDLE> bloom_bPx2nd_mutex;
 std::vector<HANDLE> bloom_bPx3rd_mutex;
@@ -439,7 +444,7 @@ int main(int argc, char **argv)	{
 	size_t rsize;
 	//if(FLAGDEBUG) { printf("[D] File: %s Line %i\n",__FILE__,__LINE__); fflush(stdout); }
 	
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 	DWORD s;
 	write_keys = CreateMutex(NULL, FALSE, NULL);
 	write_random = CreateMutex(NULL, FALSE, NULL);
@@ -1222,7 +1227,7 @@ int main(int argc, char **argv)	{
 		bloom_bP_checksums = (struct checksumsha256*)calloc(256,sizeof(struct checksumsha256));
 		checkpointer((void *)bloom_bP_checksums,__FILE__,"calloc","bloom_bP_checksums" ,__LINE__ -1 );
 		
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 		bloom_bP_mutex = (HANDLE*) calloc(256,sizeof(HANDLE));
 		
 #else
@@ -1234,7 +1239,7 @@ int main(int argc, char **argv)	{
 		fflush(stdout);
 		bloom_bP_totalbytes = 0;
 		for(i=0; i< 256; i++)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 			bloom_bP_mutex[i] = CreateMutex(NULL, FALSE, NULL);
 #else
 			pthread_mutex_init(&bloom_bP_mutex[i],NULL);
@@ -1251,7 +1256,7 @@ int main(int argc, char **argv)	{
 
 		printf("[+] Bloom filter for %" PRIu64 " elements ",bsgs_m2);
 		
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 		bloom_bPx2nd_mutex = (HANDLE*) calloc(256,sizeof(HANDLE));
 #else
 		bloom_bPx2nd_mutex = (pthread_mutex_t*) calloc(256,sizeof(pthread_mutex_t));
@@ -1263,7 +1268,7 @@ int main(int argc, char **argv)	{
 		checkpointer((void *)bloom_bPx2nd_checksums,__FILE__,"calloc","bloom_bPx2nd_checksums" ,__LINE__ -1 );
 		bloom_bP2_totalbytes = 0;
 		for(i=0; i< 256; i++)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 			bloom_bPx2nd_mutex[i] = CreateMutex(NULL, FALSE, NULL);
 #else
 			pthread_mutex_init(&bloom_bPx2nd_mutex[i],NULL);
@@ -1278,7 +1283,7 @@ int main(int argc, char **argv)	{
 		printf(": %.2f MB\n",(float)((float)(uint64_t)bloom_bP2_totalbytes/(float)(uint64_t)1048576));
 		
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 		bloom_bPx3rd_mutex = (HANDLE*) calloc(256,sizeof(HANDLE));
 #else
 		bloom_bPx3rd_mutex = (pthread_mutex_t*) calloc(256,sizeof(pthread_mutex_t));
@@ -1292,7 +1297,7 @@ int main(int argc, char **argv)	{
 		printf("[+] Bloom filter for %" PRIu64 " elements ",bsgs_m3);
 		bloom_bP3_totalbytes = 0;
 		for(i=0; i< 256; i++)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 			bloom_bPx3rd_mutex[i] = CreateMutex(NULL, FALSE, NULL);
 #else
 			pthread_mutex_init(&bloom_bPx3rd_mutex[i],NULL);
@@ -1639,7 +1644,7 @@ int main(int argc, char **argv)	{
 				printf("\r[+] processing %lu/%lu bP points : %i%%\r",FINISHED_ITEMS,bsgs_m,(int) (((double)FINISHED_ITEMS/(double)bsgs_m)*100));
 				fflush(stdout);
 				
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				tid = (HANDLE*)calloc(NTHREADS, sizeof(HANDLE));
 				checkpointer((void *)tid,__FILE__,"calloc","tid" ,__LINE__ -1 );
 				bPload_mutex = (HANDLE*) calloc(NTHREADS,sizeof(HANDLE));
@@ -1656,7 +1661,7 @@ int main(int argc, char **argv)	{
 				memset(bPload_threads_available,1,NTHREADS);
 				
 				for(i = 0; i < NTHREADS; i++)	{
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 					bPload_mutex[i] = CreateMutex(NULL, FALSE, NULL);
 #else
 					pthread_mutex_init(&bPload_mutex[i],NULL);
@@ -1682,7 +1687,7 @@ int main(int argc, char **argv)	{
 								//if(FLAGDEBUG) printf("[D] Salir OK\n");
 							}
 							//if(FLAGDEBUG) printf("[I] %lu to %lu\n",bPload_temp_ptr[i].from,bPload_temp_ptr[i].to);
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 							tid[i] = CreateThread(NULL, 0, thread_bPload_2blooms, (void*) &bPload_temp_ptr[i], 0, &s);
 #else
 							s = pthread_create(&tid[i],NULL,thread_bPload_2blooms,(void*) &bPload_temp_ptr[i]);
@@ -2205,7 +2210,7 @@ int main(int argc, char **argv)	{
 					}
 				}
 				
-#ifdef _WIN64
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				WaitForSingleObject(bsgs_thread, INFINITE);
 #else
 				pthread_mutex_lock(&bsgs_thread);
@@ -2256,7 +2261,7 @@ int main(int argc, char **argv)	{
 				printf("%s",buffer);
 				fflush(stdout);
 				THREADOUTPUT = 0;			
-#ifdef _WIN64
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 				ReleaseMutex(bsgs_thread);
 #else
 				pthread_mutex_unlock(&bsgs_thread);
@@ -2269,7 +2274,7 @@ int main(int argc, char **argv)	{
 		}
 	}while(continue_flag);
 	printf("\nEnd\n");
-#ifdef _WIN64
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 	CloseHandle(write_keys);
 	CloseHandle(write_random);
 	CloseHandle(bsgs_thread);
@@ -2352,7 +2357,7 @@ int searchbinary(struct address_value *buffer,char *data,int64_t array_length) {
 	return r;
 }
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 DWORD WINAPI thread_process_minikeys(LPVOID vargp) {
 #else
 void *thread_process_minikeys(void *vargp)	{

--- a/oldbloom/bloom.cpp
+++ b/oldbloom/bloom.cpp
@@ -72,14 +72,14 @@ static int oldbloom_check_add(struct oldbloom * bloom, const void * buffer, int 
   int r;
   for (i = 0; i < bloom->hashes; i++) {
     x = (a + b*i) % bloom->bits;
-#if defined(_WIN64) && !defined(__CYGWIN__)
-	WaitForSingleObject(bloom->mutex, INFINITE);
-	r = oldtest_bit_set_bit(bloom->bf, x, add);
-	ReleaseMutex(bloom->mutex);
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+  WaitForSingleObject(bloom->mutex, INFINITE);
+  r = oldtest_bit_set_bit(bloom->bf, x, add);
+  ReleaseMutex(bloom->mutex);
 #else
-	pthread_mutex_lock((pthread_mutex_t*)&bloom->mutex);
-	r = oldtest_bit_set_bit(bloom->bf, x, add);
-	pthread_mutex_unlock((pthread_mutex_t*)&bloom->mutex);
+  pthread_mutex_lock((pthread_mutex_t*)&bloom->mutex);
+  r = oldtest_bit_set_bit(bloom->bf, x, add);
+  pthread_mutex_unlock((pthread_mutex_t*)&bloom->mutex);
 #endif
     if (r) {
       hits++;

--- a/oldbloom/oldbloom.h
+++ b/oldbloom/oldbloom.h
@@ -8,9 +8,10 @@
 #ifndef _OLDBLOOM_H
 #define _OLDBLOOM_H
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
 #include <windows.h>
 #else
+#include <pthread.h>
 #endif
 #ifdef __cplusplus
 extern "C" {
@@ -44,7 +45,7 @@ struct oldbloom
   uint8_t checksum[32];
   uint8_t checksum_backup[32];
   uint8_t *bf;
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
   HANDLE mutex;
 #else
   pthread_mutex_t mutex;

--- a/os_random.c
+++ b/os_random.c
@@ -1,0 +1,30 @@
+/* Implementation of os_getrandom: uses /dev/urandom on POSIX and BCryptGenRandom on Windows */
+#include "os_random.h"
+
+#include <stddef.h>
+#include <stdio.h>
+
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#include <windows.h>
+#include <bcrypt.h>
+
+int os_getrandom(void *buf, size_t buflen) {
+    if (buf == NULL || buflen == 0) return -1;
+    NTSTATUS st = BCryptGenRandom(NULL, (PUCHAR)buf, (ULONG)buflen, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+    return (st == 0) ? 0 : -1;
+}
+
+#else
+#include <fcntl.h>
+#include <unistd.h>
+
+int os_getrandom(void *buf, size_t buflen) {
+    if (buf == NULL || buflen == 0) return -1;
+    int fd = open("/dev/urandom", O_RDONLY);
+    if (fd < 0) return -1;
+    ssize_t r = read(fd, buf, buflen);
+    close(fd);
+    return (r == (ssize_t)buflen) ? 0 : -1;
+}
+
+#endif

--- a/os_random.h
+++ b/os_random.h
@@ -1,0 +1,19 @@
+/* Portable random bytes provider
+ * Provides os_getrandom(void *buf, size_t len) -> 0 on success, -1 on error
+ */
+#ifndef OS_RANDOM_H
+#define OS_RANDOM_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int os_getrandom(void *buf, size_t buflen);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OS_RANDOM_H */

--- a/rmd160/rmd160.h
+++ b/rmd160/rmd160.h
@@ -28,7 +28,7 @@ typedef struct RMD160Context {
 
 #define RIPEMD160Context RMD160Context
 
-#ifdef _WIN64
+#if defined(_WIN64) && !defined(__MINGW32__) && !defined(__MINGW64__)
 #else
 #include <sys/cdefs.h>
 
@@ -41,7 +41,7 @@ void   RMD160Final(unsigned char [RMD160_HASHBYTES], RMD160_CTX *);
 char * RMD160End(RMD160_CTX *, char *);
 char * RMD160File(const char *, char *);
 void RMD160Data(const unsigned char *, unsigned int, char *);
-#ifdef _WIN64
+#if defined(_WIN64) && !defined(__MINGW32__) && !defined(__MINGW64__)
 #else
 __END_DECLS
 

--- a/secp256k1/Int.cpp
+++ b/secp256k1/Int.cpp
@@ -975,10 +975,10 @@ char * Int::GetC64Str(int nbDigit) {
   tmp[1] = 0;
   for (int i = 0; i< nbDigit; i++) {
     if (bits64[i] != 0) {
-#ifdef _WIN64
-      sprintf(bStr, "0x%016I64XULL", bits64[i]);
+#if defined(_WIN64) && !defined(__MINGW32__) && !defined(__MINGW64__)
+  sprintf(bStr, "0x%016I64XULL", bits64[i]);
 #else
-      sprintf(bStr, "0x%" PRIx64  "ULL", bits64[i]);
+  sprintf(bStr, "0x%" PRIx64  "ULL", bits64[i]);
 #endif
     } else {
       sprintf(bStr, "0ULL");

--- a/secp256k1/Random.cpp
+++ b/secp256k1/Random.cpp
@@ -18,17 +18,7 @@
 
 #include "Random.h"
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
-#else
-#include <sys/random.h>
-#endif
-
-#ifdef __unix__
-#ifdef __CYGWIN__
-#else
-#include <linux/random.h>
-#endif
-#endif
+#include "../os_random.h"
 
 #define  RK_STATE_LEN 624
 
@@ -66,7 +56,7 @@ void rk_seed(unsigned long seed, rk_state *state)
 #define UPPER_MASK 0x80000000UL
 #define LOWER_MASK 0x7fffffffUL
 
-#ifdef _WIN64
+#if defined(_WIN64) && !defined(__MINGW32__) && !defined(__MINGW64__)
 // Disable "unary minus operator applied to unsigned type, result still unsigned" warning.
 #pragma warning(disable : 4146)
 #endif
@@ -120,23 +110,20 @@ void rseed(unsigned long seed) {
 	//srand(seed);
 }
 
-#if defined(_WIN64) && !defined(__CYGWIN__)
+#if defined(_WIN64) && !defined(__MINGW32__) && !defined(__MINGW64__)
 unsigned long rndl() {
-	return rk_random(&localState);
+  return rk_random(&localState);
 }
 #else
 unsigned long rndl() {
-	unsigned long r;
-	int bytes_read = getrandom(&r, sizeof(unsigned long), GRND_NONBLOCK );
-	if (bytes_read > 0) {
-		return r;
-	}
-	else	{
-		/*Fail safe */
-		return rk_random(&localState);
-	}
+  unsigned long r;
+  if (os_getrandom(&r, sizeof(unsigned long)) == 0) {
+    return r;
+  } else {
+    /* Fail safe */
+    return rk_random(&localState);
+  }
 }
-	
 #endif
 
 // Returns a uniform distributed double value in the interval ]0,1[

--- a/secp256k1/SECP256K1.cpp
+++ b/secp256k1/SECP256K1.cpp
@@ -585,7 +585,7 @@ void Secp256K1::GetHash160(int type,bool compressed,
   Point &k0,Point &k1,Point &k2,Point &k3,
   uint8_t *h0,uint8_t *h1,uint8_t *h2,uint8_t *h3) {
 
-#ifdef WIN64
+#if defined(_WIN64) && !defined(__MINGW32__) && !defined(__MINGW64__)
   __declspec(align(16)) unsigned char sh0[64];
   __declspec(align(16)) unsigned char sh1[64];
   __declspec(align(16)) unsigned char sh2[64];
@@ -747,7 +747,7 @@ void Secp256K1::GetHash160_fromX(int type,unsigned char prefix,
   Int *k0,Int *k1,Int *k2,Int *k3,
   uint8_t *h0,uint8_t *h1,uint8_t *h2,uint8_t *h3) {
 
-#ifdef WIN64
+#if defined(_WIN64) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
   __declspec(align(16)) unsigned char sh0[64];
   __declspec(align(16)) unsigned char sh1[64];
   __declspec(align(16)) unsigned char sh2[64];

--- a/test.bat
+++ b/test.bat
@@ -1,0 +1,5 @@
+:: Run keyhunt with debug, capture output and pause so window stays open
+:: Removes quiet (-q) and enables debug (-d) to show diagnostics
+keyhunt.exe -d -m address -f tests/66.txt -b 66 -l compress -R -s 10 -t4 > run.log 2>&1
+type run.log
+pause

--- a/win_compat.c
+++ b/win_compat.c
@@ -1,0 +1,36 @@
+/* Minimal Windows compatibility wrappers for sockets */
+#include "win_compat.h"
+
+#if (defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)) && !defined(__CYGWIN__)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+
+int socket_init(void) {
+    WSADATA wsa;
+    if (WSAStartup(MAKEWORD(2,2), &wsa) != 0) return -1;
+    return 0;
+}
+
+void socket_cleanup(void) {
+    WSACleanup();
+}
+
+int socket_close(int sockfd) {
+    if (closesocket((SOCKET)sockfd) == SOCKET_ERROR) return -1;
+    return 0;
+}
+
+#else
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+
+int socket_init(void) { return 0; }
+void socket_cleanup(void) { (void)0; }
+int socket_close(int sockfd) { return close(sockfd); }
+
+#endif

--- a/win_compat.h
+++ b/win_compat.h
@@ -1,0 +1,22 @@
+/* Minimal Windows compatibility wrappers for sockets */
+#ifndef WIN_COMPAT_H
+#define WIN_COMPAT_H
+
+/* Initialize socket subsystem on Windows, no-op on POSIX. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(__MINGW32__) && !defined(__MINGW64__)
+#include "win_thread_compat.h"
+#endif
+
+int socket_init(void);
+void socket_cleanup(void);
+int socket_close(int sockfd);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WIN_COMPAT_H */

--- a/win_thread_compat.c
+++ b/win_thread_compat.c
@@ -1,0 +1,112 @@
+/* Implementation of compatibility layer that maps basic WinAPI thread/mutex usage to pthreads under MinGW. */
+#include "win_thread_compat.h"
+
+#if (defined(__MINGW32__) || defined(__MINGW64__)) && !defined(__CYGWIN__)
+
+#include <stdio.h>
+#include <string.h>
+
+struct compat_handle_s {
+    int type; /* 0=mutex, 1=thread */
+    union {
+        pthread_mutex_t mutex;
+        pthread_t thread;
+    } u;
+    int detached; /* for threads */
+};
+
+HANDLE CreateMutex(LPVOID lpMutexAttributes, int bInitialOwner, const char* lpName) {
+    (void)lpMutexAttributes; (void)lpName;
+    struct compat_handle_s *h = (struct compat_handle_s*)malloc(sizeof(struct compat_handle_s));
+    if(!h) return NULL;
+    h->type = 0;
+    h->detached = 0;
+    pthread_mutex_init(&h->u.mutex, NULL);
+    if (bInitialOwner) pthread_mutex_lock(&h->u.mutex);
+    return h;
+}
+
+int ReleaseMutex(HANDLE hMutex) {
+    if (!hMutex) return -1;
+    struct compat_handle_s *h = (struct compat_handle_s*)hMutex;
+    if (h->type != 0) return -1;
+    return pthread_mutex_unlock(&h->u.mutex);
+}
+
+typedef struct thread_start_arg_s {
+    LPTHREAD_START_ROUTINE func;
+    LPVOID param;
+    struct compat_handle_s *h;
+} thread_start_arg_t;
+
+static void* thread_thunk(void *arg) {
+    thread_start_arg_t *a = (thread_start_arg_t*)arg;
+    DWORD ret = 0;
+    if (a && a->func) {
+        /* call the Windows-style thread function */
+        ret = a->func(a->param);
+    }
+    free(a);
+    return (void*)(uintptr_t)ret;
+}
+
+HANDLE CreateThread(LPVOID lpThreadAttributes, size_t dwStackSize, LPTHREAD_START_ROUTINE lpStartAddress, LPVOID lpParameter, DWORD dwCreationFlags, DWORD* lpThreadId) {
+    (void)lpThreadAttributes; (void)dwStackSize; (void)dwCreationFlags;
+    struct compat_handle_s *h = (struct compat_handle_s*)malloc(sizeof(struct compat_handle_s));
+    if (!h) return NULL;
+    h->type = 1;
+    h->detached = 0;
+    thread_start_arg_t *arg = (thread_start_arg_t*)malloc(sizeof(thread_start_arg_t));
+    if (!arg) { free(h); return NULL; }
+    arg->func = lpStartAddress;
+    arg->param = lpParameter;
+    arg->h = h;
+    pthread_t thr;
+    int r = pthread_create(&thr, NULL, thread_thunk, arg);
+    if (r != 0) {
+        free(arg);
+        free(h);
+        return NULL;
+    }
+    h->u.thread = thr;
+    if (lpThreadId) {
+        *lpThreadId = (DWORD)(uintptr_t)thr;
+    }
+    return h;
+}
+
+DWORD WaitForSingleObject(HANDLE hHandle, DWORD dwMilliseconds) {
+    (void)dwMilliseconds; /* ignoring timeout, only blocking waits supported */
+    if (!hHandle) return (DWORD)-1;
+    struct compat_handle_s *h = (struct compat_handle_s*)hHandle;
+    if (h->type == 0) {
+        pthread_mutex_lock(&h->u.mutex);
+        return 0; /* WAIT_OBJECT_0 */
+    } else if (h->type == 1) {
+        /* join thread */
+        pthread_join(h->u.thread, NULL);
+        return 0;
+    }
+    return (DWORD)-1;
+}
+
+int CloseHandle(HANDLE hObject) {
+    if (!hObject) return -1;
+    struct compat_handle_s *h = (struct compat_handle_s*)hObject;
+    if (h->type == 0) {
+        pthread_mutex_destroy(&h->u.mutex);
+        free(h);
+        return 0;
+    } else if (h->type == 1) {
+        if(!h->detached) pthread_detach(h->u.thread);
+        free(h);
+        return 0;
+    }
+    return -1;
+}
+
+void Sleep(DWORD milliseconds) {
+    usleep((useconds_t)milliseconds * 1000);
+}
+
+#endif /* MinGW */

--- a/win_thread_compat.h
+++ b/win_thread_compat.h
@@ -1,0 +1,51 @@
+/* Minimal thread/mutex compatibility layer for MinGW: map CreateThread/WaitForSingleObject/CreateMutex to pthreads.
+ * For native Windows builds (MSVC), these are standard WinAPI calls and this header is a no-op.
+ */
+#ifndef WIN_THREAD_COMPAT_H
+#define WIN_THREAD_COMPAT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Only enable compatibility layer for MinGW (not MSVC) */
+#if (defined(__MINGW32__) || defined(__MINGW64__)) && !defined(__CYGWIN__)
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+typedef unsigned long DWORD;
+typedef void* LPVOID;
+#ifndef WINAPI
+#define WINAPI
+#endif
+typedef DWORD (WINAPI *LPTHREAD_START_ROUTINE)(LPVOID);
+
+#ifndef INFINITE
+#define INFINITE 0xFFFFFFFFu
+#endif
+#ifndef WAIT_OBJECT_0
+#define WAIT_OBJECT_0 0u
+#endif
+
+/* Define a HANDLE-like opaque pointer for MinGW that encapsulates pthread types */
+typedef struct compat_handle_s compat_handle_t;
+typedef compat_handle_t* HANDLE;
+
+/* Maps several WinAPI calls to pthreads */
+HANDLE CreateMutex(LPVOID lpMutexAttributes, int bInitialOwner, const char* lpName);
+int ReleaseMutex(HANDLE hMutex);
+HANDLE CreateThread(LPVOID lpThreadAttributes, size_t dwStackSize, LPTHREAD_START_ROUTINE lpStartAddress, LPVOID lpParameter, DWORD dwCreationFlags, DWORD* lpThreadId);
+DWORD WaitForSingleObject(HANDLE hHandle, DWORD dwMilliseconds);
+int CloseHandle(HANDLE hObject);
+void Sleep(DWORD milliseconds);
+
+#endif /* MinGW/posix fallback */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WIN_THREAD_COMPAT_H */


### PR DESCRIPTION
- Updated conditional compilation for Windows to exclude MinGW and Cygwin.
- Introduced a compatibility layer for sockets and threading for MinGW.
- Added os_getrandom implementation for portable random byte generation.
- Refactored mutex and thread handling to use pthreads in MinGW.
- Improved code organization and readability across multiple files.
- Ensured consistent handling of random number generation across platforms.